### PR TITLE
add -q/--quiet option to POD

### DIFF
--- a/lib/App/Inotify/Hookable.pm
+++ b/lib/App/Inotify/Hookable.pm
@@ -574,6 +574,10 @@ The regexes match after any C</> in the path or the beginning of the string.
 
 Spew out some verbose debug output while running.
 
+=head2 C<-q> or C<--[no-]quiet>
+
+Don't log noisy information
+
 =head1 ACKNOWLEDGMENT
 
 This module was originally developed at and for Booking.com. With


### PR DESCRIPTION

In Debian we are currently applying the following patch to
App-Inotify-Hookable.
We thought you might be interested in it too.

    Description: add -q/--quiet option to POD
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/984471
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2021-03-07
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/inotify-hookable/raw/master/debian/patches/pod-quiet.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
